### PR TITLE
Fix zero-width assertion in `automaton` checker

### DIFF
--- a/modules/recheck-core/shared/src/main/scala/codes/quine/labs/recheck/automaton/EpsNFA.scala
+++ b/modules/recheck-core/shared/src/main/scala/codes/quine/labs/recheck/automaton/EpsNFA.scala
@@ -53,21 +53,24 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
   }
 
   /** Converts this ε-NFA to ordered NFA with ε-elimination. */
-  def toOrderedNFA(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[Q])] = toOrderedNFA(Int.MaxValue)
-
+  def toOrderedNFA(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[(Q, Set[CharKind])])] =
+    toOrderedNFA(Int.MaxValue)
+  
   /** Converts this ε-NFA to ordered NFA with ε-elimination. */
-  def toOrderedNFA(maxNFASize: Int)(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[Q])] =
+  def toOrderedNFA(maxNFASize: Int)(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[(Q, Set[CharKind])])] =
     ctx.interrupt {
       val hasLineAssertion = tau.values
         .collect { case Assert(k, _) => k }
         .exists(k => k == AssertKind.LineBegin || k == AssertKind.LineEnd)
       val inputTerminatorKind = if (hasLineAssertion) CharKind.LineTerminator else CharKind.Normal
 
-      // Obtains a set of possible character information.
-      val charInfoSet = alphabet.pairs.iterator.map(_._2).toSet ++ Set(inputTerminatorKind)
+      // Obtains a set of possible character kinds.
+      val charKindSet = alphabet.pairs.iterator.map(_._2).toSet ++ Set(inputTerminatorKind)
+
+      type P = (Q, Set[CharKind])
 
       /** Skips ε-transitions from the state and collects not ε-transition or terminal state. */
-      def buildClosure(k0: CharKind, ks: Set[CharKind], q: Q, loops: Set[Int]): Seq[(Q, Option[Consume[Q]])] =
+      def buildClosure(k0: CharKind, ks: Set[CharKind], q: Q, loops: Set[Int]): Seq[(P, Option[Consume[Q]])] =
         ctx.interrupt {
           if (ks.isEmpty) Vector.empty
           else
@@ -82,26 +85,26 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
                 else buildClosure(k0, ks, q1, loops)
               case Some(Consume(chs, q1, pos)) =>
                 val newChs = chs.filter { case (_, k) => ks.contains(k) }
-                if (newChs.nonEmpty) Vector((q, Some(Consume(newChs, q1, pos))))
+                if (newChs.nonEmpty) Vector(((q, ks), Some(Consume(newChs, q1, pos))))
                 else Vector.empty
               case None =>
-                if (ks.contains(inputTerminatorKind)) Vector((q, None))
+                if (ks.contains(inputTerminatorKind)) Vector(((q, Set.empty), None))
                 else Vector.empty
             }
         }
-      val closureCache = mutable.Map.empty[(CharKind, Q), Seq[(Q, Option[Consume[Q]])]]
-      def closure(k0: CharKind, q: Q): Seq[(Q, Option[Consume[Q]])] =
-        closureCache.getOrElseUpdate((k0, q), buildClosure(k0, charInfoSet, q, Set.empty))
+      val closureCache = mutable.Map.empty[(CharKind, Q), Seq[(P, Option[Consume[Q]])]]
+      def closure(k0: CharKind, q: Q): Seq[(P, Option[Consume[Q]])] =
+        closureCache.getOrElseUpdate((k0, q), buildClosure(k0, charKindSet, q, Set.empty))
 
       val closureInit = closure(inputTerminatorKind, init)
 
-      val queue = mutable.Queue.empty[(CharKind, Seq[(Q, Option[Consume[Q]])])]
-      val newStateSet = mutable.Set.empty[(CharKind, Seq[Q])]
+      val queue = mutable.Queue.empty[(CharKind, Seq[(P, Option[Consume[Q]])])]
+      val newStateSet = mutable.Set.empty[(CharKind, Seq[P])]
       val newInits = Vector((inputTerminatorKind, closureInit.map(_._1)))
-      val newAcceptSet = Set.newBuilder[(CharKind, Seq[Q])]
-      val newDelta = Map.newBuilder[((CharKind, Seq[Q]), IChar), Seq[(CharKind, Seq[Q])]]
+      val newAcceptSet = Set.newBuilder[(CharKind, Seq[P])]
+      val newDelta = Map.newBuilder[((CharKind, Seq[P]), IChar), Seq[(CharKind, Seq[P])]]
       val newSourcemap = mutable.Map
-        .empty[((CharKind, Seq[Q]), IChar, (CharKind, Seq[Q])), Seq[Location]]
+        .empty[((CharKind, Seq[P]), IChar, (CharKind, Seq[P])), Seq[Location]]
         .withDefaultValue(Vector.empty)
       var deltaSize = 0
 
@@ -111,8 +114,8 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
       while (queue.nonEmpty) ctx.interrupt {
         val (c0, qps) = queue.dequeue()
         val qs0 = qps.map(_._1)
-        if (qs0.contains(accept)) newAcceptSet.addOne((c0, qs0))
-        val d = mutable.Map.empty[IChar, Seq[(CharKind, Seq[Q])]].withDefaultValue(Vector.empty)
+        if (qs0.map(_._1).contains(accept)) newAcceptSet.addOne((c0, qs0))
+        val d = mutable.Map.empty[IChar, Seq[(CharKind, Seq[P])]].withDefaultValue(Vector.empty)
         for ((_, p) <- qps) {
           p match {
             case Some(Consume(chs, q1, loc)) =>

--- a/modules/recheck-core/shared/src/main/scala/codes/quine/labs/recheck/automaton/EpsNFA.scala
+++ b/modules/recheck-core/shared/src/main/scala/codes/quine/labs/recheck/automaton/EpsNFA.scala
@@ -55,7 +55,7 @@ final case class EpsNFA[Q](alphabet: ICharSet, stateSet: Set[Q], init: Q, accept
   /** Converts this ε-NFA to ordered NFA with ε-elimination. */
   def toOrderedNFA(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[(Q, Set[CharKind])])] =
     toOrderedNFA(Int.MaxValue)
-  
+
   /** Converts this ε-NFA to ordered NFA with ε-elimination. */
   def toOrderedNFA(maxNFASize: Int)(implicit ctx: Context): OrderedNFA[IChar, (CharKind, Seq[(Q, Set[CharKind])])] =
     ctx.interrupt {

--- a/modules/recheck-core/shared/src/test/scala/codes/quine/labs/recheck/automaton/AutomatonCheckerSuite.scala
+++ b/modules/recheck-core/shared/src/test/scala/codes/quine/labs/recheck/automaton/AutomatonCheckerSuite.scala
@@ -47,11 +47,13 @@ class AutomatonCheckerSuite extends munit.FunSuite {
 
   test("AutomatonChecker.check: polynomial") {
     val a = IChar('a')
-    val other = IChar('a').complement(false)
+    val at = IChar('@')
+    val other1 = a.complement(false)
+    val other2 = IChar.Word.union(at).complement(false)
     assertEquals(
       check("^.*a.*a$", "s"),
       Success(
-        Polynomial(2, Witness(Seq((Seq.empty, Seq(a))), Seq(other)), Hotspot(Seq(Spot(1, 2, Heat), Spot(3, 5, Heat))))
+        Polynomial(2, Witness(Seq((Seq.empty, Seq(a))), Seq(other1)), Hotspot(Seq(Spot(1, 2, Heat), Spot(3, 5, Heat))))
       )
     )
     assertEquals(
@@ -59,7 +61,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       Success(
         Polynomial(
           2,
-          Witness(Seq((Seq.empty, Seq(a, a))), Seq(a, other, a, a, a)),
+          Witness(Seq((Seq(a), Seq(a, a))), Seq(other1, a, a, a)),
           Hotspot(Seq(Spot(2, 4, Heat), Spot(6, 7, Heat), Spot(8, 10, Heat)))
         )
       )
@@ -69,8 +71,18 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       Success(
         Polynomial(
           3,
-          Witness(Seq((Seq.empty, Seq(a)), (Seq.empty, Seq(a))), Seq(other)),
+          Witness(Seq((Seq.empty, Seq(a)), (Seq.empty, Seq(a))), Seq(other1)),
           Hotspot(Seq(Spot(1, 2, Heat), Spot(3, 5, Heat), Spot(6, 8, Heat)))
+        )
+      )
+    )
+    assertEquals(
+      check("^(.+?)aa\\b[^@]*@", "s"),
+      Success(
+        Polynomial(
+          2,
+          Witness(Seq((Seq(at), Seq(a, a, other2))), Seq.empty),
+          Hotspot(Seq(Spot(2, 3, Heat), Spot(6, 8, Heat), Spot(10, 14, Heat)))
         )
       )
     )
@@ -104,7 +116,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
       check("^(aa|b|aab)*$", ""),
       Success(
         Exponential(
-          Witness(Seq((Seq(a), Seq(a, a, a, b, a))), Seq(other2)),
+          Witness(Seq((Seq(a, a), Seq(b, a, a, b, a, a))), Seq(other2)),
           Hotspot(Seq(Spot(2, 4, Heat), Spot(5, 6, Heat), Spot(7, 10, Heat)))
         )
       )

--- a/modules/recheck-core/shared/src/test/scala/codes/quine/labs/recheck/automaton/EpsNFASuite.scala
+++ b/modules/recheck-core/shared/src/test/scala/codes/quine/labs/recheck/automaton/EpsNFASuite.scala
@@ -86,16 +86,17 @@ class EpsNFASuite extends munit.FunSuite {
         5 -> LoopExit(0, 6)
       )
     )
+    val q36: Seq[(Int, Set[CharKind])] = Seq((3, Set(CharKind.LineTerminator, CharKind.Normal)), (6, Set.empty))
     assertEquals(
       nfa1.toOrderedNFA,
-      OrderedNFA[IChar, (CharKind, Seq[Int])](
+      OrderedNFA[IChar, (CharKind, Seq[(Int, Set[CharKind])])](
         Set(IChar('\n'), IChar('\n').complement(false)),
-        Set((CharKind.LineTerminator, Seq(3, 6))),
-        Vector((CharKind.LineTerminator, Seq(3, 6))),
-        Set((CharKind.LineTerminator, Seq(3, 6))),
+        Set((CharKind.LineTerminator, q36)),
+        Vector((CharKind.LineTerminator, q36)),
+        Set((CharKind.LineTerminator, q36)),
         Map(
-          ((CharKind.LineTerminator, Seq(3, 6)), IChar('\n')) -> Vector(
-            (CharKind.LineTerminator, Seq(3, 6))
+          ((CharKind.LineTerminator, q36), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, q36)
           )
         )
       )
@@ -118,33 +119,44 @@ class EpsNFASuite extends munit.FunSuite {
         9 -> Assert(AssertKind.WordBoundary, 10)
       )
     )
+    val q4: Seq[(Int, Set[CharKind])] = Seq((4, Set(CharKind.LineTerminator)))
+    val q45: Seq[(Int, Set[CharKind])] = Seq(
+      (4, Set(CharKind.LineTerminator, CharKind.Word, CharKind.Normal)),
+      (5, Set(CharKind.LineTerminator, CharKind.Word, CharKind.Normal))
+    )
+    val q54510: Seq[(Int, Set[CharKind])] = Seq(
+      (5, Set(CharKind.Word)),
+      (4, Set(CharKind.LineTerminator, CharKind.Word, CharKind.Normal)),
+      (5, Set(CharKind.LineTerminator, CharKind.Word, CharKind.Normal)),
+      (10, Set.empty)
+    )
     assertEquals(
       nfa2.toOrderedNFA,
       OrderedNFA(
         Set(IChar('\n'), IChar('a'), IChar('a').union(IChar('\n')).complement(false)),
         Set(
-          (CharKind.LineTerminator, Seq(4)),
-          (CharKind.LineTerminator, Seq(4, 5)),
-          (CharKind.Word, Seq(5, 4, 5, 10))
+          (CharKind.LineTerminator, q4),
+          (CharKind.LineTerminator, q45),
+          (CharKind.Word, q54510)
         ),
-        Vector((CharKind.LineTerminator, Seq(4))),
-        Set((CharKind.Word: CharKind, Seq(5, 4, 5, 10))),
+        Vector((CharKind.LineTerminator, q4)),
+        Set((CharKind.Word: CharKind, q54510)),
         Map(
-          ((CharKind.LineTerminator, Seq(4)), IChar('\n')) -> Vector(
-            (CharKind.LineTerminator, Seq(4, 5))
+          ((CharKind.LineTerminator, q4), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, q45)
           ),
-          ((CharKind.LineTerminator, Seq(4, 5)), IChar('a')) -> Vector(
-            (CharKind.Word, Seq(5, 4, 5, 10))
+          ((CharKind.LineTerminator, q45), IChar('a')) -> Vector(
+            (CharKind.Word, q54510)
           ),
-          ((CharKind.LineTerminator, Seq(4, 5)), IChar('\n')) -> Vector(
-            (CharKind.LineTerminator, Seq(4, 5))
+          ((CharKind.LineTerminator, q45), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, q45)
           ),
-          ((CharKind.Word, Seq(5, 4, 5, 10)), IChar('\n')) -> Vector(
-            (CharKind.LineTerminator, Seq(4, 5))
+          ((CharKind.Word, q54510), IChar('\n')) -> Vector(
+            (CharKind.LineTerminator, q45)
           ),
-          ((CharKind.Word, Seq(5, 4, 5, 10)), IChar('a')) -> Vector(
-            (CharKind.Word, Seq(5, 4, 5, 10)),
-            (CharKind.Word, Seq(5, 4, 5, 10))
+          ((CharKind.Word, q54510), IChar('a')) -> Vector(
+            (CharKind.Word, q54510),
+            (CharKind.Word, q54510)
           )
         )
       )


### PR DESCRIPTION
In the past, in `EpsNFA#toOrderedNFA`, next character kinds are omitted after refining a transition, so it equates two states which should be distinguish.

This commit fixes it to include next character kind in state.
Now, we can check `/^.+?aa[^@]@/` correctly.

## Changes

- Fix zero-width assertion in `automaton` checker