### PR TITLE
Update copyright year 2022 -> 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 TSUYUSATO "MakeNowJust" Kitsune
+Copyright (c) 2020-2023 TSUYUSATO "MakeNowJust" Kitsune
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@
 
 MIT License.
 
-2020-2022 (C) TSUYUSATO "MakeNowJust" Kitsune
+2020-2023 (C) TSUYUSATO "MakeNowJust" Kitsune

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -124,7 +124,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © 2020-2022 TSUYUSATO "MakeNowJust" Kitsune. Built with Docusaurus.`,
+        copyright: `Copyright © 2020-2023 TSUYUSATO "MakeNowJust" Kitsune. Built with Docusaurus.`,
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
## Changes

- Update copyright year 2022 -> 2023 in `README.md`, `LICENSE` and `docusaurus.config.js`.