### PR TITLE
Use `$GITHUB_OUTPUT` instead of `set-output`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,9 @@ jobs:
       - id: save-version
         name: Save Version
         run: |
-          echo "version=$(sbt --error "print coreJVM/releaseVersion")" >> $GITHUB_OUTPUT
+          echo "version<<EOF" >> $GITHUB_OUTPUT
+          echo "$(sbt --error "print coreJVM/releaseVersion")" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         with:
           path: modules/recheck-js/target/scala-2.13/recheck-js-opt/recheck.js

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - id: save-version
         name: Save Version
         run: |
-          echo "::set-output name=version::$(sbt --error "print coreJVM/releaseVersion")"
+          echo "version=$(sbt --error "print coreJVM/releaseVersion")" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         with:
           path: modules/recheck-js/target/scala-2.13/recheck-js-opt/recheck.js


### PR DESCRIPTION
## Changes

- Use `$GITHUB_OUTPUT` instead of `set-output`
  - See <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>