### PR TITLE
Remove deprecated `System.runFinalizer` call

### DIFF
--- a/modules/recheck-cli/src/main/scala/codes/quine/labs/recheck/cli/AgentCommand.scala
+++ b/modules/recheck-cli/src/main/scala/codes/quine/labs/recheck/cli/AgentCommand.scala
@@ -106,7 +106,6 @@ class AgentCommand(threadSize: Int, io: RPC.IO = RPC.IO.stdio) {
   /** Enforces GC. */
   def gc(): Unit = {
     System.gc()
-    System.runFinalization()
   }
 
   def run(): Unit =


### PR DESCRIPTION
## Changes

- Remove deprecated `System.runFinalizer` call