### PR TITLE
Show `stderr` output of agent processes

### DIFF
--- a/packages/recheck/src/lib/agent.ts
+++ b/packages/recheck/src/lib/agent.ts
@@ -149,7 +149,7 @@ export async function start(
   return await new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       windowsHide: true,
-      stdio: ["pipe", "pipe", "ignore"],
+      stdio: ["pipe", "pipe", "inherit"],
     });
 
     const onClose = () => reject(new Error("process is closed"));


### PR DESCRIPTION
Ref #758

## Changes

- Change `stdio` property of the setting on spawning agents from `"ignore"` to `"inherit"`.
  - Then, `stderr` output of agent processes will be shown.
  - It may prevent issues like #758.