### PR TITLE
Fix to decode `Duration` for `String`

### DIFF
--- a/modules/recheck-codec/shared/src/main/scala/codes/quine/labs/recheck/codec/package.scala
+++ b/modules/recheck-codec/shared/src/main/scala/codes/quine/labs/recheck/codec/package.scala
@@ -187,11 +187,8 @@ package object codec {
   /** A `Decoder` for `Duration`. */
   implicit def decodeDuration: Decoder[Duration] = (c: HCursor) =>
     if (c.value.isNull) Right(Duration.Inf)
-    else if (c.value.isNumber) c.value.asNumber.flatMap(_.toInt) match {
-      case Some(d) => Right(Duration(d, MILLISECONDS))
-      case None    => Left(DecodingFailure("Duration", c.history))
-    }
-    else Left(DecodingFailure("Duration", c.history))
+    else
+      Decoder[Int].tryDecode(c).map(t => Duration(t, MILLISECONDS)).orElse(Left(DecodingFailure("Duration", c.history)))
 
   /** A `Decoder` for `Checker`. */
   implicit def decodeChecker: Decoder[Checker] =

--- a/modules/recheck-codec/shared/src/test/scala/codes/quine/labs/recheck/codec/CodecSuite.scala
+++ b/modules/recheck-codec/shared/src/test/scala/codes/quine/labs/recheck/codec/CodecSuite.scala
@@ -215,8 +215,10 @@ class CodecSuite extends munit.FunSuite {
   test("codec.decodeDuration") {
     assertEquals(decodeDuration.decodeJson(Json.Null), Right(Duration.Inf))
     assertEquals(decodeDuration.decodeJson(100.asJson), Right(Duration(100, MILLISECONDS)))
+    assertEquals(decodeDuration.decodeJson("100".asJson), Right(Duration(100, MILLISECONDS)))
     assertEquals(decodeDuration.decodeJson(Json.True), Left(DecodingFailure("Duration", List.empty)))
     assertEquals(decodeDuration.decodeJson(123.456.asJson), Left(DecodingFailure("Duration", List.empty)))
+    assertEquals(decodeDuration.decodeJson("123.456".asJson), Left(DecodingFailure("Duration", List.empty)))
   }
 
   test("codec.decodeChecker") {


### PR DESCRIPTION
## Changes

- Fix to decode `Duration` for `String`
  - to work on browser demo