### PR TITLE
Fix to work `RECHECK_SYNC_BACKEND` correctly

### DIFF
--- a/packages/recheck/src/main.test.ts
+++ b/packages/recheck/src/main.test.ts
@@ -1,3 +1,5 @@
+import * as synckit from "synckit";
+
 import * as main from "./main";
 
 import * as env from "./lib/env";
@@ -9,6 +11,7 @@ const RECHECK_BIN = `${__dirname}/../../../modules/recheck-cli/target/native-ima
 
 jest.setTimeout(10000);
 
+jest.mock("synckit");
 jest.mock("./lib/env");
 jest.mock("./lib/java");
 jest.mock("./lib/native");
@@ -144,9 +147,12 @@ test("check: invalid", async () => {
 test("checkSync: synckit", () => {
   const backend = jest.spyOn(env, "RECHECK_SYNC_BACKEND");
   backend.mockReturnValueOnce("synckit" as any);
+  const createSyncFn = jest.spyOn(synckit, "createSyncFn");
+  createSyncFn.mockReturnValueOnce(() => ({ status: "vulnerable" }));
 
   const diagnostics = main.checkSync("^(a|a)+$", "");
   expect(diagnostics.status).toBe("vulnerable");
+  expect(createSyncFn).toHaveBeenCalled();
 });
 
 test("checkSync: pure", () => {

--- a/packages/recheck/src/main.ts
+++ b/packages/recheck/src/main.ts
@@ -102,6 +102,7 @@ export const checkSync = (
         syncFnCache = createSyncFn(require.resolve("./synckit-worker"));
       }
       syncFn = syncFnCache;
+      break;
     case "pure":
       syncFn = pure.check;
       break;


### PR DESCRIPTION
Close #870

## Changes

- Fix to work `RECHECK_SYNC_BACKEND` correctly
  * A `break` for `switch`-`case` is missing. It is easy mistake.
- Add a test case for checking whether `synckit` function has been called.
