### PR TITLE
Update JVM to use on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
         with:
-          jvm: adoptium:1.19.0.1
+          jvm: adoptium:1.21.0.2
       - name: Cache SBT
         uses: actions/cache@v4
         with:
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: coursier/setup-action@v1
         with:
-          jvm: adoptium:1.19.0.1
+          jvm: adoptium:1.21.0.2
       - name: Cache SBT
         uses: actions/cache@v4
         with:
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: coursier/setup-action@v1
         with:
-          jvm: adoptium:1.19.0.1
+          jvm: adoptium:1.21.0.2
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -172,7 +172,7 @@ jobs:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
         with:
-          jvm: adoptium:1.19.0.1
+          jvm: adoptium:1.21.0.2
       - name: Cache SBT
         uses: actions/cache@v4
         with:
@@ -210,7 +210,7 @@ jobs:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
         with:
-          jvm: adoptium:1.19.0.1
+          jvm: adoptium:1.21.0.2
       - name: Cache SBT
         uses: actions/cache@v4
         with:
@@ -244,7 +244,7 @@ jobs:
           fetch-depth: 0
       - uses: coursier/setup-action@v1
         with:
-          jvm: adoptium:1.19.0.1
+          jvm: adoptium:1.21.0.2
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,7 +3,6 @@ rules = [
   RemoveUnused,
   LeakingImplicitClassVal,
   OrganizeImports,
-  MissingFinal,
 ]
 
 OrganizeImports {

--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,6 @@ ThisBuild / scalacOptions ++= Seq(
 ThisBuild / scalafixScalaBinaryVersion := "2.13"
 ThisBuild / semanticdbEnabled := true
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
-ThisBuild / scalafixDependencies += "com.github.vovapolu" %% "scaluzzi" % "0.1.23"
 
 val releaseVersion = taskKey[String]("A release version")
 ThisBuild / releaseVersion := {


### PR DESCRIPTION
## Changes

- Update JVM to use on CI (from v19 to v21)
- Remove some scalafix plugins due to out dated.