### PR TITLE
Ensure that checkSync() and check() do not stall without the flags parameter

### DIFF
--- a/packages/recheck/src/main.ts
+++ b/packages/recheck/src/main.ts
@@ -28,6 +28,19 @@ export async function check(
   flags: string,
   params: Parameters & HasAbortSignal = {},
 ): Promise<Diagnostics> {
+  /* c8 ignore start */
+  if (typeof source !== "string") {
+    throw new TypeError(
+      `Expected 'source' to be a string, but got ${typeof source}`,
+    );
+  }
+  if (typeof flags !== "string") {
+    throw new TypeError(
+      `Expected 'flags' to be a string, but got ${typeof flags}`,
+    );
+  }
+  /* c8 ignore stop */
+
   const backend = env.RECHECK_BACKEND();
   switch (backend) {
     case "auto":
@@ -94,6 +107,19 @@ export const checkSync = (
   flags: string,
   params: Parameters = {},
 ): Diagnostics => {
+  /* c8 ignore start */
+  if (typeof source !== "string") {
+    throw new TypeError(
+      `Expected 'source' to be a string, but got ${typeof source}`,
+    );
+  }
+  if (typeof flags !== "string") {
+    throw new TypeError(
+      `Expected 'flags' to be a string, but got ${typeof flags}`,
+    );
+  }
+  /* c8 ignore stop */
+
   let syncFn: typeof pure.check | null = null;
   const backend = env.RECHECK_SYNC_BACKEND();
   switch (backend) {


### PR DESCRIPTION
This patch fixes an issue where the two functions would never finish if called without a second parameter. For example, check("^(a|a+)+$")
