### PR TITLE
Pin react-dom version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,5 +38,5 @@
       "depTypeTemplate": "compiler plugin"
     }
   ],
-  "ignoreDeps": ["hast-util-is-element", "react", "rehype-katex", "remark-math"]
+  "ignoreDeps": ["hast-util-is-element", "react", "react-dom", "rehype-katex", "remark-math"]
 }


### PR DESCRIPTION
## Changes

Pin `react-dom` version much like `react` because Docusaurus only supports React v18.