### PR TITLE
Fix #1616: resolve the windows path issue

### DIFF
--- a/packages/recheck/src/lib/exe.test.ts
+++ b/packages/recheck/src/lib/exe.test.ts
@@ -15,7 +15,7 @@ afterEach(() => {
 });
 
 test("jar", () => {
-  expect(exe.jar()).toMatch(/recheck-jar\/recheck\.jar$/);
+  expect(exe.jar()).toMatch(/recheck-jar[/\\]recheck\.jar$/);
 
   process.env["RECHECK_JAR"] = "x";
   expect(exe.jar()).toBe("x");
@@ -44,7 +44,7 @@ test("jar: invalid resolve (2)", () => {
 
 test("bin", () => {
   if (isSupported) {
-    expect(exe.bin()).toMatch(/recheck-\w+-\w+\/recheck(?:\.exe)?$/);
+    expect(exe.bin()).toMatch(/recheck-\w+-\w+[/\\]recheck(?:\.exe)?$/);
   }
 
   process.env["RECHECK_BIN"] = "x";

--- a/packages/recheck/src/lib/exe.ts
+++ b/packages/recheck/src/lib/exe.ts
@@ -13,7 +13,7 @@ export const jar: () => string | null = () => {
   try {
     const exe = __mock__require
       .resolve("recheck-jar/package.json")
-      .replace(/\/package\.json$/, "/recheck.jar");
+      .replace(/package\.json$/, "recheck.jar");
     return exe;
   } catch (err: any) {
     if (err && err.code == "MODULE_NOT_FOUND") {
@@ -60,9 +60,7 @@ export const bin: () => string | null = () => {
     /* c8 ignore next */
     const bin = isWin32 ? "recheck.exe" : "recheck";
     const pkg = `recheck-${os}-${cpu}/package.json`;
-    const exe = __mock__require
-      .resolve(pkg)
-      .replace(/\/package\.json$/, `/${bin}`);
+    const exe = __mock__require.resolve(pkg).replace(/package\.json$/, bin);
     return exe;
   } catch (err: any) {
     if (err && err.code == "MODULE_NOT_FOUND") {


### PR DESCRIPTION
Fix #1616

## Changes

This was not handling the path separator characters correctly in Windows. I fixed it.

Thank you, @Kristinita, for reporting it.