### PR TITLE
Update GH action timeout to 15 min

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Scala Build
     outputs:
       version: ${{ steps.save-version.outputs.version }}
@@ -60,7 +60,7 @@ jobs:
   scala-lint:
     needs: [build]
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Scala Lint
     steps:
       - uses: actions/checkout@v5
@@ -87,7 +87,7 @@ jobs:
 
   node-lint:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Node Lint
     steps:
       - uses: actions/checkout@v5
@@ -106,7 +106,7 @@ jobs:
 
   scala-test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Scala Test
     steps:
       - uses: actions/checkout@v5
@@ -135,7 +135,7 @@ jobs:
   node-test:
     needs: [build, node-lint]
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     strategy:
       matrix:
         node: [ 20, 22, 24 ]
@@ -186,7 +186,7 @@ jobs:
             artifact_filename: recheck-win32-x64.exe
             local_path: modules/recheck-cli/target/native-image/recheck.exe
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Scala Build (Native Binary)
     steps:
       - uses: actions/checkout@v5
@@ -226,7 +226,7 @@ jobs:
     needs: [build, scala-test]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     name: Publish to Maven Central
     steps:
       - uses: actions/checkout@v5
@@ -262,7 +262,7 @@ jobs:
     needs: [build, native-build, node-test]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Publish to NPM
     steps:
       - uses: actions/checkout@v5
@@ -334,7 +334,7 @@ jobs:
     needs: [maven-release, npm-release]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Publish GitHub Release
     steps:
       - uses: actions/checkout@v5
@@ -379,7 +379,7 @@ jobs:
     needs: [build]
     if: github.ref_name == 'main'
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Build website
     steps:
       - uses: actions/checkout@v5
@@ -411,7 +411,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: Deploy to GitHub Pages
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Changes

Recently, some CI tasks have timed out. To prevent this, this PR updates the timeout to 15 minutes.