### PR TITLE
Run the `native-build` task on a `schedule` event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
     tags: [v*]
   pull_request: {}
   workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * 5'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -167,7 +169,7 @@ jobs:
 
   native-build:
     needs: [build]
-    if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/')
+    if: github.event.schedule == '0 0 * * 5' || startsWith(github.ref, 'refs/tags/')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Changes

`native-build` task is too heavy to run on each commit. Therefore, we remove this task from commit events and add `schedule` for this.