### PR TITLE
Add the `--detectOpenHandles` option to run test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,8 +159,8 @@ jobs:
       - name: Build
         run: yarn lerna run build
       - name: Test
-        # It needs two `--` actually: one is for Yarn and the latter is for Lerna.
-        run: yarn lerna run test -- -- --coverage
+        # It needs two `--`. One is for Yarn and the latter is for Lerna.
+        run: yarn lerna run test -- -- --coverage --detectOpenHandles
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Changes

`node-test` task is flaky. To find a reason, we add the option to `jest`.