### PR TITLE
Enable `--forceExit` option of Jest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
         run: yarn lerna run build
       - name: Test
         # It needs two `--`. One is for Yarn and the latter is for Lerna.
-        run: yarn lerna run test -- -- --coverage --detectOpenHandles
+        run: yarn lerna run test -- -- --coverage --forceExit --detectOpenHandles
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Changes

We also enable `--forceExit` of Jest to find the reason for flaky tests, followed by #1627.