### PR TITLE
Unref stderr and work test on CI env correctly

### DIFF
--- a/packages/recheck/src/lib/agent.ts
+++ b/packages/recheck/src/lib/agent.ts
@@ -159,12 +159,15 @@ export async function start(
 
     // Remove references from the child process.
     child.unref();
-    /* c8 ignore next 6 */
+    /* c8 ignore next 9 */
     if ((child.stdin as any)?.unref) {
       (child.stdin as any).unref();
     }
     if ((child.stdout as any)?.unref) {
       (child.stdout as any).unref();
+    }
+    if ((child.stderr as any)?.unref) {
+      (child.stderr as any).unref();
     }
 
     // Waits `ping` method response.

--- a/packages/recheck/src/lib/exe.test.ts
+++ b/packages/recheck/src/lib/exe.test.ts
@@ -1,5 +1,7 @@
 import * as exe from "./exe";
 
+jest.mock("fs");
+
 const isSupported =
   typeof exe.osNames[process.platform] !== "undefined" &&
   typeof exe.cpuNames[process.arch] !== "undefined";
@@ -15,10 +17,20 @@ afterEach(() => {
 });
 
 test("jar", () => {
+  const existsSync = jest.spyOn(require("fs"), "existsSync");
+  existsSync.mockReturnValueOnce(true);
+
   expect(exe.jar()).toMatch(/recheck-jar[/\\]recheck\.jar$/);
 
   process.env["RECHECK_JAR"] = "x";
   expect(exe.jar()).toBe("x");
+});
+
+test("jar: not found", () => {
+  const existsSync = jest.spyOn(require("fs"), "existsSync");
+  existsSync.mockReturnValueOnce(false);
+  
+  expect(exe.jar()).toBeNull();
 });
 
 test("jar: invalid resolve (1)", () => {
@@ -43,6 +55,9 @@ test("jar: invalid resolve (2)", () => {
 });
 
 test("bin", () => {
+  const existsSync = jest.spyOn(require("fs"), "existsSync");
+  existsSync.mockReturnValueOnce(true);
+
   if (isSupported) {
     expect(exe.bin()).toMatch(/recheck-\w+-\w+[/\\]recheck(?:\.exe)?$/);
   }

--- a/packages/recheck/src/lib/exe.ts
+++ b/packages/recheck/src/lib/exe.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "fs";
 import * as env from "./env";
 
 /** Exposes this to mock `require.resolve` on testing. */
@@ -14,6 +15,13 @@ export const jar: () => string | null = () => {
     const exe = __mock__require
       .resolve("recheck-jar/package.json")
       .replace(/package\.json$/, "recheck.jar");
+
+    // On development or CI environments, the jar file may not exist.
+    /* c8 ignore next 3 */
+    if (!existsSync(exe)) {
+      return null;
+    }
+
     return exe;
   } catch (err: any) {
     if (err && err.code == "MODULE_NOT_FOUND") {
@@ -61,6 +69,13 @@ export const bin: () => string | null = () => {
     const bin = isWin32 ? "recheck.exe" : "recheck";
     const pkg = `recheck-${os}-${cpu}/package.json`;
     const exe = __mock__require.resolve(pkg).replace(/package\.json$/, bin);
+
+    // On development or CI environments, the binary file may not exist.
+    /* c8 ignore next 3 */
+    if (!existsSync(exe)) {
+      return null;
+    }
+
     return exe;
   } catch (err: any) {
     if (err && err.code == "MODULE_NOT_FOUND") {

--- a/packages/recheck/src/main.test.ts
+++ b/packages/recheck/src/main.test.ts
@@ -9,7 +9,7 @@ import * as native from "./lib/native";
 const RECHECK_JAR = `${__dirname}/../../../modules/recheck-cli/target/scala-2.13/recheck.jar`;
 const RECHECK_BIN = `${__dirname}/../../../modules/recheck-cli/target/native-image/recheck`;
 
-jest.setTimeout(10000);
+jest.setTimeout(30 * 1000);
 
 jest.mock("synckit");
 jest.mock("./lib/env");
@@ -17,7 +17,6 @@ jest.mock("./lib/java");
 jest.mock("./lib/native");
 
 beforeEach(() => {
-  jest.setTimeout(30 * 1000);
   main.__mock__.agent = undefined;
   main.__mock__.pool = null;
 });


### PR DESCRIPTION
## Changes

`node-test task shows the following error:

```
Error: Unable to access jarfile /home/runner/work/recheck/recheck/packages/recheck-jar/recheck.jar
```

To prevent this, we add to check jar and binary file existence on path resolving.