### PR TITLE
Use `lerna run test` instead of `pnpm test`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Build
         run: pnpm -r run build
       - name: Test
-        run: pnpm -r test --coverage --forceExit --detectOpenHandles
+        run: pnpm exec lerna run test -- --coverage --forceExit --detectOpenHandles
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Changes

This PR modifies to use `lerna run test` instead of `pnpm test` because its output is better than `pnpm test` on GitHub Actions UI.
