### PR TITLE
Add `d.ts` to the ESLint plugin

### DIFF
--- a/packages/eslint-plugin-redos/index.d.ts
+++ b/packages/eslint-plugin-redos/index.d.ts
@@ -1,0 +1,19 @@
+import type { Rule, Config, FlatConfig } from "eslint";
+
+declare const plugin: {
+  meta: {
+    name: string;
+    version: string;
+  },
+  rules: {
+    "no-vulnerable": Rule.RuleModule;
+  },
+  configs: {
+    recommended: Config;
+    flat: {
+      recommended: FlatConfig;
+    };
+  };
+};
+
+export = plugin;

--- a/packages/eslint-plugin-redos/package.json
+++ b/packages/eslint-plugin-redos/package.json
@@ -13,7 +13,9 @@
     "url": "https://github.com/makenowjust-labs/recheck.git"
   },
   "main": "lib/main.js",
+  "types": "index.d.ts",
   "files": [
+    "index.d.ts",
     "lib"
   ],
   "scripts": {

--- a/packages/eslint-plugin-redos/src/main.ts
+++ b/packages/eslint-plugin-redos/src/main.ts
@@ -27,4 +27,4 @@ Object.assign(plugin.configs, {
   },
 });
 
-export = plugin;
+export = plugin as ESLint.Plugin;


### PR DESCRIPTION
Fix #1693

## Changes

This PR adds a `d.ts` file to `eslint-plugin-redos`. Now, the following works without any type errors:

```typescript
import { defineConfig } from "eslint/config";
import redosPlugin from "eslint-plugin-redos";

export default defineConfig([
  redosPlugin.configs.flat.recommended,
]);
```