### PR TITLE
Use dark theme by default in devices that prefer it

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -142,6 +142,9 @@ const config = {
         darkTheme: darkCodeTheme,
         additionalLanguages: ["java", "scala"],
       },
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
       image: "img/social.png",
       algolia: {
         appId: "G4MPILTIZG",


### PR DESCRIPTION
## Changes

<!-- Explain changes in this PR. -->

Website only.

If the browser prefers the dark theme, the website now uses it by default.

https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme