### PR TITLE
chore(eslint-plugin-redos): add bugs metadata

### DIFF
--- a/packages/eslint-plugin-redos/package.json
+++ b/packages/eslint-plugin-redos/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "https://github.com/makenowjust-labs/recheck.git"
   },
+  "bugs": {
+    "url": "https://github.com/makenowjust-labs/recheck/issues"
+  },
   "main": "lib/main.js",
   "types": "index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary

- add `bugs.url` metadata for `eslint-plugin-redos` pointing to this repository's issue tracker
- leave runtime code, dependencies, package versioning, exports, and published files unchanged

## Verification

- package metadata assertion with Node
- `git diff --check`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter eslint-plugin-redos run lint`
- `corepack pnpm --filter eslint-plugin-redos run typecheck`
- `corepack pnpm --filter eslint-plugin-redos run build`
- `npm pack --dry-run --ignore-scripts --json ./packages/eslint-plugin-redos`

## Note

`corepack pnpm --filter eslint-plugin-redos run test` currently requires the workspace `recheck` package's generated Scala/JS artifact (`modules/recheck-js/target/.../recheck.js`) to exist first. I did not include that generated artifact in this metadata-only PR.